### PR TITLE
chore: currently datalabeling is limited to due to covid 19

### DIFF
--- a/samples/snippets/import_data_test.py
+++ b/samples/snippets/import_data_test.py
@@ -40,6 +40,7 @@ def dataset():
     testing_lib.delete_dataset(dataset.name)
 
 
+@pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_import_data(capsys, dataset):
     @backoff.on_exception(
         backoff.expo, ServerError, max_time=testing_lib.RETRY_DEADLINE


### PR DESCRIPTION

Fixes #59  🦕
Due to COVID, service is limited.