### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "datalabeling",
     "name_pretty": "Google Cloud Data Labeling",
     "product_documentation": "https://cloud.google.com/data-labeling/docs/",
-    "client_documentation": "https://googleapis.dev/python/datalabeling/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/datalabeling/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Python Client for Data Labeling API (`Beta`_)
 
 .. _Beta: https://github.com/GoogleCloudPlatform/google-cloud-python/blob/main/README.rst
 .. _Data Labeling API: https://cloud.google.com/data-labeling
-.. _Client Library Documentation: https://googleapis.dev/python/datalabeling/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/datalabeling/latest
 .. _Product Documentation:  https://cloud.google.com/data-labeling/docs/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.